### PR TITLE
Resolve problema de credenciais ao tentar conexão com AsyncClient

### DIFF
--- a/src/main/java/tech/buildrun/sqs/SqsApplication.java
+++ b/src/main/java/tech/buildrun/sqs/SqsApplication.java
@@ -20,6 +20,6 @@ public class SqsApplication implements CommandLineRunner {
 	@Override
 	public void run(String... args) throws Exception {
 		var SQS = "https://localhost.localstack.cloud:4566/000000000000/minha-fila";
-		sqsTemplate.send(SQS, new MyMessage("meu valor de start"));
+		sqsTemplate.send(SQS, new MyMessage("My automatic start message"));
 	}
 }

--- a/src/main/java/tech/buildrun/sqs/config/SqsConfig.java
+++ b/src/main/java/tech/buildrun/sqs/config/SqsConfig.java
@@ -2,6 +2,7 @@ package tech.buildrun.sqs.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
@@ -14,6 +15,7 @@ public class SqsConfig {
     public SqsAsyncClient sqsAsyncClient() {
         return SqsAsyncClient.builder()
                 .endpointOverride(URI.create("http://localhost:4566"))
+                .credentialsProvider(AnonymousCredentialsProvider.create())
                 .region(Region.SA_EAST_1)
                 .build();
     }

--- a/src/main/java/tech/buildrun/sqs/controller/SqsProducer.java
+++ b/src/main/java/tech/buildrun/sqs/controller/SqsProducer.java
@@ -1,0 +1,24 @@
+package tech.buildrun.sqs.controller;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.buildrun.sqs.consumer.MyMessage;
+
+@RestController
+@RequestMapping("sqs/v1/messages")
+public class SqsProducer {
+
+    @Autowired
+    private SqsTemplate sqsTemplate;
+
+
+    @PostMapping("/send")
+    public void sendMessage(@RequestBody MyMessage message){
+        var SQS = "https://localhost.localstack.cloud:4566/000000000000/minha-fila";
+        sqsTemplate.send(SQS, message);
+    }
+}


### PR DESCRIPTION
O foco principal desse pull request é corrigir o problema de validação de credenciais quando tentamos nos conectar ao client, agora o parâmetro de credenciais é obrigatório. 

Como não temos essa informação no nível do exemplo proposto, foquei em cria-las dinamicamente.

Também aproveitei e criei um controller para facilitar o manuseio/teste do envio e recebimento de mensagens.